### PR TITLE
system_server: replace sys_resource with sys_ptrace

### DIFF
--- a/system_server.te
+++ b/system_server.te
@@ -51,15 +51,12 @@ allow system_server self:capability {
     net_raw
     sys_boot
     sys_nice
-    sys_resource
+    sys_ptrace
     sys_time
     sys_tty_config
 };
 
 wakelock_use(system_server)
-
-# Triggered by /proc/pid accesses, not allowed.
-dontaudit system_server self:capability sys_ptrace;
 
 # Trigger module auto-load.
 allow system_server kernel:system module_request;


### PR DESCRIPTION
Commit https://android.googlesource.com/kernel/common/+/f0ce0eee added
CAP_SYS_RESOURCE as a capability check which would allow access to
sensitive /proc/PID files. However, in an SELinux based world, allowing
this access causes CAP_SYS_RESOURCE to duplicate what CAP_SYS_PTRACE
(without :process ptrace) already provides.

Use CAP_SYS_PTRACE instead of CAP_SYS_RESOURCE.

Test: Device boots, functionality remains identical, no sys_resource
denials from system_server.
Bug: 34951864
Bug: 38496951
Change-Id: I04d745b436ad75ee1ebecf0a61c6891858022e34
(cherry picked from commit 448669540c0b7c22ee8b8293217818f8f92238b6)
(cherry picked from commit c15810c527ffa6953108f68365cf2df9e0868096)